### PR TITLE
feat: add imported styles to example

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,19 +1,33 @@
 import React from 'react';
-import { Text, Pressable } from 'react-native';
+import { Alert, Text, Pressable } from 'react-native';
 import {
 	SafeAreaProvider,
 	SafeAreaView,
 } from 'react-native-safe-area-context';
-
 import styled from 'react-native-styled.macro';
 import { useWindowVariant } from 'react-native-styled.macro/lib';
 
+import { useStyles } from './styles';
+
 export default function App() {
 	const variants = useWindowVariant();
+	const styles = useStyles();
+
+	function handlePress() {
+		Alert.alert(
+			'Button Pressed',
+			'You pressed a button',
+			[{ text: 'OK' }],
+			{
+				cancelable: false,
+			}
+		);
+	}
 
 	return (
 		<SafeAreaProvider>
 			<SafeAreaView {...styled(['flex-1', 'items-center'])}>
+				{/* Inline Styling */}
 				<Pressable
 					{...styled(
 						[
@@ -29,12 +43,18 @@ export default function App() {
 						],
 						variants
 					)}
+					onPress={handlePress}
 				>
 					<Text
 						{...styled(['px-2', 'py-1', 'text-base', 'text-white'])}
 					>
 						Press me
 					</Text>
+				</Pressable>
+
+				{/* Imported Styling */}
+				<Pressable {...styles.button} onPress={handlePress}>
+					<Text {...styles.buttonText}>Press me too</Text>
 				</Pressable>
 			</SafeAreaView>
 		</SafeAreaProvider>

--- a/example/styles.ts
+++ b/example/styles.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+
+import styled from 'react-native-styled.macro';
+import { useWindowVariant } from 'react-native-styled.macro/lib';
+
+export function useStyles() {
+	const variants = useWindowVariant();
+
+	const styles = useMemo(() => {
+		return {
+			button: {
+				...styled(
+					[
+						'mx-2',
+						'my-4',
+						'border',
+						'rounded-full',
+						'border-teal-600',
+						'bg-teal-600',
+						'sm:bg-green-600',
+						'md:bg-teal-600',
+						'lg:bg-yellow-600',
+						'xl:bg-orange-600',
+					],
+					variants
+				),
+			},
+			buttonText: {
+				...styled(
+					['px-2', 'py-1', 'text-base', 'text-white'],
+					variants
+				),
+			},
+			container: {
+				...styled(['flex-1', 'items-center'], variants),
+			},
+		};
+	}, [variants]);
+
+	return styles;
+}


### PR DESCRIPTION
As with Tailwind, utility styling can be quite verbose. This makes it difficult to understand a component's structure at a glance.

In this sample, I've used a hook to add styling to a new button to improve readability. This makes it very similar to the common practice of developing stylesheets like:

```
const styles = Stylesheet.create({
  button: { ....},
  buttonText: { ....},
  container: { ....},
})
```

Please let me know if you would like this modified somehow or have suggestions to improve it.

P.S. I've also added a handle for the buttons' `onPress` event so the developer knows the code is working properly.